### PR TITLE
Fix conflicts with Android plugin + add conditional compilation logic

### DIFF
--- a/Plugins/Crittercism_IOS_Scripts/CrittercismInitIOS.cs
+++ b/Plugins/Crittercism_IOS_Scripts/CrittercismInitIOS.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
-public class CrittercismInit : MonoBehaviour
+public class CrittercismInitIOS : MonoBehaviour
 {
 	/// <summary>
 	/// Your Crittercism App ID.  Every app has a special identifier that allows Crittercism
@@ -14,7 +14,9 @@ public class CrittercismInit : MonoBehaviour
     
 	void Awake ()
 	{
+#if UNITY_IOS
 		CrittercismIOS.Init (CrittercismAppID);
+#endif
 		Destroy (this);
 	}
 }


### PR DESCRIPTION
You can't have two scripts with the same name in the default namespace,
so if you add both the iOS and Android unity plugins, it won't compile.
Renaming the init script fixes the issue. Also wrap init in platform
conditional compile to automatically disable iOS init when not compiling for iOS.