### PR TITLE
AGNT-1229 Stop reporting LogType.Assert's as crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*.sw[m-p]
+
+# Local
+archive/
+
 # =============== #
 # Unity generated #
 # =============== #
@@ -29,7 +34,8 @@ x64/
 *.vspscc
 *.vssscc
 .builds
-TestiOS/TestApp/
+*MrsCritter*
+*TestApp*
 
 # ===================================== #
 # Visual Studio / MonoDevelop generated #

--- a/Plugins/Crittercism_IOS_Scripts/CrittercismIOS.cs
+++ b/Plugins/Crittercism_IOS_Scripts/CrittercismIOS.cs
@@ -278,7 +278,7 @@ public static class CrittercismIOS
 
 	static private void _OnDebugLogCallbackHandler (string name, string stack, LogType type)
 	{
-		if (LogType.Exception == type || LogType.Assert == type) {
+		if (LogType.Exception == type) {
 			if (Application.platform == RuntimePlatform.IPhonePlayer) {
 				// Should never get here since the Init() call would have bailed on the same if statement
 				Crittercism_LogUnhandledException (name, name, stack, crUnityId);

--- a/TestiOS/Assets/Plugins/Crittercism_IOS_Scripts/CrittercismIOS.cs
+++ b/TestiOS/Assets/Plugins/Crittercism_IOS_Scripts/CrittercismIOS.cs
@@ -278,7 +278,7 @@ public static class CrittercismIOS
 
 	static private void _OnDebugLogCallbackHandler (string name, string stack, LogType type)
 	{
-		if (LogType.Exception == type || LogType.Assert == type) {
+		if (LogType.Exception == type) {
 			if (Application.platform == RuntimePlatform.IPhonePlayer) {
 				// Should never get here since the Init() call would have bailed on the same if statement
 				Crittercism_LogUnhandledException (name, name, stack, crUnityId);


### PR DESCRIPTION
LogType.Assert's will no longer be reported as crashes.
